### PR TITLE
PR core exprs

### DIFF
--- a/src/vertigo/core.clj
+++ b/src/vertigo/core.clj
@@ -767,17 +767,31 @@
      (p/+ x# sum#)))
 
 (defmacro mean
-  "Returns the mean of all numbers within the sequence.
+  "Returns the mean (float) of all numbers within the sequence.
+
       (mean s)
+
   or
-      (mean s :step 2 :limit 10)"
+
+      (mean s :step 2 :limit 10)
+
+  Note that the sum/count will be cast to floats before division, and
+  will be subject to floating point math"
   [s & options]
   `(let [[^java.lang.Long summed# ^java.lang.Long counted#]
          (doreduce [x# ~s ~@options] [sum# 0, cnt# 0]
            [(p/+ sum# x#) (p/+ 1 cnt#)])]
-      (p/div summed# counted#)))
+      (p/div (float summed#) (float counted#))))
 
 (defmacro compares
+  "Compares x in a sequence to each x before. Used to implement macros
+  such as max
+
+      (compares s >)
+
+  or min
+
+      (compares s <)"
   [[s & options] operator]
   `(doreduce [x# ~s ~@options] [comps# 0]
      (if (~operator x# comps#)
@@ -785,10 +799,16 @@
        comps#)))
 
 (defmacro max!
+  "Returns max value of all numbers in sequence
+
+  (max s)"
   [s & options]
   `(compares [~s ~@options] p/>))
 
 (defmacro min!
+  "Returns min value of all numbers in sequence
+
+  (min s)"
   [s & options]
   `(compares [~s ~@options] p/<))
 

--- a/test/vertigo/core_test.clj
+++ b/test/vertigo/core_test.clj
@@ -125,7 +125,7 @@
         ^:s/int64 every (c/marshal-seq s/int64 [1 1 1 1 1])]
     (is (= (c/sum fiver) 10))
     (is (true? (c/every? [x every] (= x 1))))
-    (is (= (c/mean fiver) 2))
+    (is (= (c/mean fiver) 2.0))
     (is (= (c/max! fiver) 4))
     (is (= (c/min! fiver) 0))))
 


### PR DESCRIPTION
What a cool library! I have some code written using hiphip + primitive arrays, but this is a better use case for me- I basically want take up as little in-memory space as possible, and I'm happy with the benchmarks so far.

This implements a few new core operators, but I had some issues with the `break` statement. Is it meant to actually be quoted? Because when quoted, it at least works for `every`. I'm getting strange behavior otherwise: 

``` clojure
user=> (def ^:s/int64 mean-two (c/marshal-seq s/int64 [0 1 2 3 4]))
#'user/mean-two
user=> (def ^:s/int64 ones (c/marshal-seq s/int64 [1 1 1 1 1]))
#'user/ones
user=> (c/every? [x mean-two] (pos? x))
true
user=> (c/every? [x ones] (= x 1))
true
user=> (c/every? [x ones] (neg? x))
nil
user=> (c/any? [x ones] (= x 1))
nil
user=> (c/any? [x mean-two] (pos? x))
nil
```

Sorry about the auto whitespace cleanup - I can probably revert it if you want.
